### PR TITLE
serverless: add missing try/except 

### DIFF
--- a/Serverless/txt2srt.py
+++ b/Serverless/txt2srt.py
@@ -16,9 +16,12 @@ def update_srt(langfile, subs):
     with open(langfile, encoding="utf8") as f:
         lines = f.readlines()
     i = 0
-    for line in lines:
-        subs[i].content = line
-        i += 1
+    try:
+        for line in lines:
+            subs[i].content = line
+            i += 1
+    except Exception as e:
+        print(e)
     return subs
 
 


### PR DESCRIPTION
fixing an issue where the translation process would crash the tool and cease execution

Hello, I've been enjoying your tool this last weekend, utilizing the serverless program with great success. But it wouldn't work until I implemented this change, which was added to the server code but wasn't copied here.